### PR TITLE
Use Base.isperm() to check validity of the permutation.

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -18,9 +18,7 @@ immutable Permutation
     data::Array{Int,1}
     function Permutation(dat::Array{Int,1})
         n = length(dat)
-        if sort(dat) != [1:n]
-            error("Improper array: must be a permutation of 1:n")
-        end
+        isperm(dat) || error("Improper array: must be a permutation of 1:n")
         new(dat)
     end
 end


### PR DESCRIPTION
This is more efficient than the previous method.
