### PR TITLE
Updated for Julia v0.4-dev

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -30,11 +30,11 @@ end
 
 # create the k'th permutation of 1:n
 function Permutation(n,k)
-    return Permutation(nthperm([1:n],k))
+    return Permutation(nthperm(collect(1:n),k))
 end
 
 # create the identity permutation
-Permutation(n::Int) = Permutation([1:n])
+Permutation(n::Int) = Permutation(collect(1:n))
 
 RandomPermutation(n::Int) = Permutation(randperm(n))
 
@@ -199,7 +199,7 @@ function permpower!{T<:Real}(p::AbstractVector{T},
     n == 0 && (for i in onep:lenp pret[i] = i end; return )
     n < 0  && (permpower!(invperm(p), pret, ptmp, -n); return )
     n == 1 && (copy!(pret,p); return)
-    permpower!(p, ptmp, pret,int(floor(n/2)))
+    permpower!(p, ptmp, pret,floor(Int, n/2))
     if iseven(n)
         for i in onep:lenp pret[i] = ptmp[ptmp[i]] end
     else
@@ -223,7 +223,7 @@ function matrix(p::Permutation, sparse::Bool = false)
     if sparse
         A = speye(Int,n)
     else
-        A = int(eye(n))
+        A = eye(Int, n)
     end
     return A[array(p),:]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Base.Test
 using Permutations
-p = Permutation([7:-1:1])
+p = Permutation(collect(7:-1:1))
 i = Permutation(7)
 @test p*p == i
 @test p == inv(p)


### PR DESCRIPTION
This commit suppresses deprecation warnings when using Permutations.jl in

Julia version 0.4.0-dev+4476 (2015-04-24 14:43 UTC) Commit 54e9ed1

Changed [1:n] to collect(1:n)
Changed int(eye(...)) to eye(Int, ...)