### PR TITLE
Add CoxeterGenerator, CoxeterDecomposition

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
+Compat 
 Combinatorics

--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -296,4 +296,29 @@ end
 # hash function so Permutations can be keys in dictionaries, etc.
 hash(p::Permutation, h::UInt64) = hash(p.data,h)
 
+
+#####
+# Decomposing into Coxeter generators
+#####
+
+coxetergenerator(n, i) = Permutation([1:i-1; i+1; i; i+2:n])
+
+decompose(P::Permutation) = decompose!(Permutation(copy(P.data)))
+function _decompose!(P::Permutation)
+    n = length(P)
+    data = P.data
+    ret = Int[]
+    while !issorted(data)
+        for k=1:n-1
+            if data[k] > data[k+1]
+                data[k], data[k+1] =  data[k+1], data[k]
+                push!(ret, k)
+            end
+        end
+    end
+    reverse!(ret)
+end
+
+decompose!(P::Permutation) = coxetergenerator.(length(P), _decompose!(P))
+
 end # end of module Permutations

--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -3,10 +3,11 @@
 
 module Permutations
 
-import Base.length, Base.show, Base.inv, Base.reverse
-import Base.==, Base.getindex, Base.*, Base.^, Base.sign
-import Base.hash, Base.getindex
-import Combinatorics.nthperm
+import Base: length, show, inv, reverse, ==, getindex, *, ^, sign, hash, getindex,
+                Matrix, Array, AbstractMatrix, AbstractArray, Array,
+                SparseMatrixCSC, AbstractSparseMatrix, AbstractSparseArray, sparse
+
+import Combinatorics: nthperm
 
 export Permutation, RandomPermutation
 export length, getindex, array, two_row
@@ -14,17 +15,21 @@ export inv, cycles, cycle_string
 export order, matrix, fixed_points
 export longest_increasing, longest_decreasing, reverse, sign
 export hash
+export CoxeterGenerator, CoxeterDecomposition
 
 # Defines the Permutation class. Permutations are bijections of 1:n.
+
+
+abstract type AbstractPermutation end
 
 """
 * `Permutation(list)` creates a new `Permutation`. Here `list` must be a rearrangement of `1:n`.
 * `Permutation(n)` creates the identity `Permutation` of `1:n`.
 * `Permutation(n,k)` creates the `k`'th `Permutation` of `1:n`.
 """
-struct Permutation
-    data::Array{Int,1}
-    function Permutation(dat::Array{Int,1})
+struct Permutation <: AbstractPermutation
+    data::Vector{Int}
+    function Permutation(dat::Vector{Int})
         n = length(dat)
         if sort(dat) != collect(1:n)
             error("Improper array: must be a permutation of 1:n")
@@ -32,6 +37,8 @@ struct Permutation
         new(dat)
     end
 end
+
+Permutation(v::AbstractVector) = Permutation(Vector{Int}(v))
 
 # create the k'th permutation of 1:n
 function Permutation(n,k)
@@ -64,13 +71,6 @@ function getindex(p::Permutation, k::Int)
     return p.data[k]
 end
 
-# Convert this Permutation into a one-dimensional array of integers
-"""
-`array(p::Permutation)` returns the list `[p(k) for k=1:n]`.
-"""
-function array(p::Permutation)
-    return collect(p.data)
-end
 
 # Create a two-row representation of this permutation
 """
@@ -216,17 +216,41 @@ end
 
 # Represent as a permtuation matrix.
 """
-`matrix(p)` returns the permutation matrix for the `Permutation` `p`.
+`Matrix(p)` returns the permutation matrix for the `Permutation` `p`.
 """
-function matrix(p::Permutation, sparse::Bool = false)
+function Matrix{T}(p::Permutation) where T
     n = length(p)
-    if sparse
-        A = speye(Int,n)
-    else
-        A = eye(Int,n)   #  int(eye(n))
-    end
-    return A[array(p),:]
+    A = eye(T,n)   #  int(eye(n))
+    return A[p.data,:]
 end
+
+Matrix(p::Permutation) = Matrix{Int}(p)
+Array(p::Permutation) = Matrix(p)
+AbstractMatrix(p::Permutation) = Matrix(p)
+AbstractArray(p::Permutation) = Matrix(p)
+
+Array{T}(p::Permutation) where T = Matrix{T}(p)
+AbstractMatrix{T}(p::Permutation) where T = Matrix{T}(p)
+AbstractArray{T}(p::Permutation) where T = Matrix{T}(p)
+
+
+"""
+`SparseMatrixCSC(p)` returns the permutation matrix for the `Permutation` `p`.
+"""
+function SparseMatrixCSC{T}(p::Permutation) where T
+    n = length(p)
+    A = speye(T,n)   #  int(eye(n))
+    return A[p.data,:]
+end
+
+SparseMatrixCSC(p::Permutation) = SparseMatrixCSC{Int}(p)
+AbstractSparseMatrix(p::Permutation) = SparseMatrixCSC{Int}(p)
+AbstractSparseArray(p::Permutation) = SparseMatrixCSC{Int}(p)
+AbstractSparseMatrix{T}(p::Permutation) where T = SparseMatrixCSC{T}(p)
+AbstractSparseArray{T}(p::Permutation) where T = SparseMatrixCSC{T}(p)
+
+sparse(p::Permutation) = SparseMatrixCSC(p)
+
 
 # find the fixed points of a Permutation
 """
@@ -301,10 +325,26 @@ hash(p::Permutation, h::UInt64) = hash(p.data,h)
 # Decomposing into Coxeter generators
 #####
 
-coxetergenerator(n, i) = Permutation([1:i-1; i+1; i; i+2:n])
+struct CoxeterGenerator <: AbstractPermutation
+    n::Int
+    i::Int
+end
 
-decompose(P::Permutation) = decompose!(Permutation(copy(P.data)))
-function _decompose!(P::Permutation)
+length(sᵢ::CoxeterGenerator) = sᵢ.n
+Permutation(P::CoxeterGenerator) = Permutation([1:P.i-1; P.i+1; P.i; P.i+2:P.n])
+
+function show(io::IO, p::CoxeterGenerator)
+    print(io, "length $(p.n) permutation: s_$(p.i)")
+end
+
+struct CoxeterDecomposition <: AbstractPermutation
+    terms::Vector{CoxeterGenerator} # TODO: How do you make sure this decomposition is unique?
+end
+
+Permutation(P::CoxeterDecomposition) = *(Permutation.(P.terms)...)
+CoxeterDecomposition(P::Permutation) = CoxeterDecomposition!(Permutation(copy(P.data)))
+CoxeterDecomposition!(P::Permutation) = CoxeterDecomposition(CoxeterGenerator.(length(P), _coxeterdecomposition!(P)))
+function _coxeterdecomposition!(P::Permutation)
     n = length(P)
     data = P.data
     ret = Int[]
@@ -319,6 +359,22 @@ function _decompose!(P::Permutation)
     reverse!(ret)
 end
 
-decompose!(P::Permutation) = coxetergenerator.(length(P), _decompose!(P))
+==(A::CoxeterDecomposition, B::CoxeterDecomposition) = A.terms == B.terms
+
+*(A::CoxeterGenerator, B::CoxeterGenerator) = CoxeterDecomposition([A,B])
+*(A::CoxeterGenerator, B::CoxeterDecomposition) = CoxeterDecomposition([A; B.terms])
+*(A::CoxeterDecomposition, B::CoxeterGenerator) = CoxeterDecomposition([A.terms; B])
+*(A::CoxeterDecomposition, B::CoxeterDecomposition) = CoxeterDecomposition([A.terms; B.terms])
+
+function show(io::IO, p::CoxeterDecomposition)
+    print(io, "length $(first(p.terms).n) permutation: ")
+    for s in p.terms
+        print(io, "s_$(s.i)")
+    end
+end
+
+@deprecate array(p::Permutation) p.data
+@deprecate matrix(p::Permutation, sparse::Bool = false) sparse ? sparse(p) : Matrix(p)
+
 
 end # end of module Permutations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,40 +1,58 @@
-using Base.Test
+using Compat.Test
 using Permutations
-p = Permutation(collect(7:-1:1))
-i = Permutation(7)
-@test p*p == i
-@test p == inv(p)
-a =[2,3,1,6,7,8,5,4,9]
-p = Permutation(a)
-@test order(p) == 6
-@test p^6 == Permutation(9)
-@test p^-5 == p
-@test array(p)==a
 
-q = Permutation([1,5,3,9,4,8,6,7,2])
-@test p*q != q*p
-@test q[2] == 5
+@testset "Permutation" begin
+    p = Permutation(7:-1:1)
+    i = Permutation(7)
+    @test p*p == i
+    @test p == inv(p)
+    a =[2,3,1,6,7,8,5,4,9]
+    p = Permutation(a)
+    @test order(p) == 6
+    @test p^6 == Permutation(9)
+    @test p^-5 == p
+    @test p.data == a
 
-P = matrix(p)
-Q = matrix(q)
-@test P*Q == matrix(q*p)
-@test P' == matrix(inv(p))
+    q = Permutation([1,5,3,9,4,8,6,7,2])
+    @test p*q != q*p
+    @test q[2] == 5
 
-row = [1,3,5,2,4,6]
-p = Permutation(row)
-@test length(p) == 6
-@test p[1] == 1
-@test length(longest_increasing(p)) == 4
-@test length(longest_decreasing(p)) == 2
-@test length(fixed_points(p)) == 2
-@test sign(p) == -1
-@test hash(p) == hash(p.data)
+    P = Matrix(p)
+    Q = Matrix(q)
+    @test P*Q == Matrix(q*p)
+    @test P' == Matrix(inv(p))
 
-M = two_row(p)
-@test M[2,:] == row
+    row = [1,3,5,2,4,6]
+    p = Permutation(row)
+    @test length(p) == 6
+    @test p[1] == 1
+    @test length(longest_increasing(p)) == 4
+    @test length(longest_decreasing(p)) == 2
+    @test length(fixed_points(p)) == 2
+    @test sign(p) == -1
+    @test hash(p) == hash(p.data)
 
-@test Permutation(6,1) == Permutation(6)
+    M = two_row(p)
+    @test M[2,:] == row
 
-p = RandomPermutation(10)
-@test p*inv(p) == Permutation(10)
-@test reverse(reverse(p)) == p
+    @test Permutation(6,1) == Permutation(6)
+
+    p = RandomPermutation(10)
+    @test p*inv(p) == Permutation(10)
+    @test reverse(reverse(p)) == p
+end
+
+@testset "CoxeterDecomposition" begin
+    n = 10
+    p = RandomPermutation(n)
+    c = CoxeterDecomposition(p)
+    @test p == Permutation(c)
+    s₂ = CoxeterGenerator(n, 2)
+    @test Permutation(s₂) == Permutation([1; 3; 2; 4:n])
+
+    @test s₂*c isa CoxeterDecomposition
+    @test c*s₂ isa CoxeterDecomposition
+    @test s₂*s₂ isa CoxeterDecomposition
+    @test s₂*c == CoxeterDecomposition([s₂])*c
+    @test Permutation(s₂*c) == Permutation(CoxeterDecomposition([s₂])*c) == Permutation(s₂)*p
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,16 @@ end
     @test s₂*c isa CoxeterDecomposition
     @test c*s₂ isa CoxeterDecomposition
     @test s₂*s₂ isa CoxeterDecomposition
-    @test s₂*c == CoxeterDecomposition([s₂])*c
-    @test Permutation(s₂*c) == Permutation(CoxeterDecomposition([s₂])*c) == Permutation(s₂)*p
+    @test s₂*c == CoxeterDecomposition(s₂)*c
+    @test Permutation(s₂*c) == Permutation(CoxeterDecomposition(s₂)*c) == Permutation(s₂)*p
+
+    @test inv(c)*c == CoxeterDecomposition(n, Int[])
+
+    @test CoxeterDecomposition(5, [3,4,1]) == CoxeterDecomposition(5, [1,3,4])
+    @test CoxeterDecomposition(5, [2,1,3,4,1]) == CoxeterDecomposition(5, [2,3,4])
+    @test CoxeterDecomposition(5, [1,3,4,3,4,3,4,1]) == CoxeterDecomposition(5, Int[])
+
+    @test Permutation(CoxeterDecomposition(5, Int[])).data ≈ 1:5
+    @test Permutation(CoxeterDecomposition(5, [1])).data == [2; 1; 3:5]
+    @test inv(CoxeterDecomposition(6, [1,3,5])) == CoxeterDecomposition(6, [1,3,5])
 end


### PR DESCRIPTION
This PR adds CoxeterGenerator, CoxeterDecomposition

It also deprecates some of the un-julian code: E.g., use `Matrix(p)` instead of `matrix(p)`.