### PR TITLE
Reverse order of *(::Permutation, ::Permutation) (#12 )

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -85,7 +85,7 @@ end
 
 # Composition of two permutations
 *(p::Permutation) = p
-function *(p::Permutation, q::Permutation)
+function *(q::Permutation, p::Permutation)
     n = length(p)
     if n != length(q)
         error("Cannot compose Permutations of different lengths")
@@ -93,6 +93,8 @@ function *(p::Permutation, q::Permutation)
     @inbounds dat = [ p.data[q.data[k]] for k in 1:n ]
     return Permutation(dat)
 end
+
+*(p::Permutation, v::AbstractVector) = v[p.data]
 
 # Inverse of a permutation
 """
@@ -410,7 +412,7 @@ function _coxeterdecomposition!(P::Permutation)
             end
         end
     end
-    reverse!(ret)
+    ret
 end
 
 ==(A::CoxeterDecomposition, B::CoxeterDecomposition) = A.terms == B.terms

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ using Permutations
 
     P = Matrix(p)
     Q = Matrix(q)
-    @test P*Q == Matrix(q*p)
+    @test P*Q == Matrix(p*q)
     @test P' == Matrix(inv(p))
 
     row = [1,3,5,2,4,6]
@@ -40,7 +40,18 @@ using Permutations
     p = RandomPermutation(10)
     @test p*inv(p) == Permutation(10)
     @test reverse(reverse(p)) == p
+
+
+    P = Permutation([4,2,1,3])
+    v = randn(4)
+    @test P*v == v[[4,2,1,3]]
+    a,b,c,d = Permutation([2,1,3,4]),Permutation([1,2,4,3]),
+                Permutation([1,3,2,4]),Permutation([2,1,3,4])
+
+    @test a*(b*(c*(d*v))) == (a*b*c*d)*v
+    @test Matrix(a*b*c*d) == Matrix(a)*Matrix(b)*Matrix(c)*Matrix(d)
 end
+
 
 @testset "CoxeterDecomposition" begin
     n = 10


### PR DESCRIPTION
I also added `*(P::Permutation, v::AbstractVector)`. 

(We could think about making `Permutation <: AbstractMatrix{Int}`.)

