### PR TITLE
Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "0.7 - 1.4"
+julia = "0.7 - 1"
 Combinatorics = "1.0"
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "≥ 0.7.0"
+julia = "1.3, 1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The Registrator is complaining [here](https://github.com/JuliaRegistries/General/pull/14500) that `julia` needs an upper bound. So I've updated this.

There's some detail on this hyphen notation here: 
https://julialang.github.io/Pkg.jl/v1/compatibility/#Hyphen-specifiers-1

So this should allow any version of Julia strictly less than 2.0.