### PR TITLE
Avoid stack overflow

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -370,13 +370,13 @@ function _coxeter_reduce!(terms::Vector{Int})
             deleteat!(terms, i:i+1)
             @goto start
         end
-        # sort using s_is_j = s_js_i
+        # sort using sᵢsⱼ = sⱼsᵢ
         if terms[i+1] ≠ terms[i]-1 && terms[i+1] ≠ terms[i]+1 && terms[i] > terms[i+1]
             terms[i], terms[i+1] = terms[i+1], terms[i]
             @goto start
         end
     end
-    # (s_is_{i+1})^3 = I
+    # (sᵢsᵢ₊₁)^3 = I
     for i = 1:length(terms)-5
         if terms[i]+1 == terms[i+1] == terms[i+2]+1 == terms[i+3] == terms[i+4]+1 == terms[i+5]
             deleteat!(terms, i:i+5)

--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -346,7 +346,7 @@ struct CoxeterGenerator <: AbstractPermutation
     n::Int
     i::Int
     function CoxeterGenerator(n::Int, i::Int)
-        1 ≤ i ≤ n-1 || throw(ArgumentError("$i must be between 1 and $n-1"))
+        1 ≤ i ≤ n-1 || throw(ArgumentError("$i must be between 1 and $n-1"))
         new(n, i)
     end
 end
@@ -394,7 +394,7 @@ struct CoxeterDecomposition <: AbstractPermutation
     terms::Vector{Int}
     function CoxeterDecomposition(n::Int, terms::Vector{Int})
         for t in terms
-            1 ≤ t ≤ n-1 || throw(ArgumentError("$t must be between 1 and $n-1"))
+            1 ≤ t ≤ n-1 || throw(ArgumentError("$t must be between 1 and $n-1"))
         end
         new(n, _coxeter_reduce!(terms))
     end

--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -363,21 +363,24 @@ end
 # https://en.wikipedia.org/wiki/Symmetric_group#Generators_and_relations
 # combined with a sorting for uniqueness
 function _coxeter_reduce!(terms::Vector{Int})
+    @label start
     for i = 1:length(terms)-1
         # sᵢ^2 = I
         if terms[i] == terms[i+1]
-            return _coxeter_reduce!(deleteat!(terms, i:i+1))
+            deleteat!(terms, i:i+1)
+            @goto start
         end
         # sort using s_is_j = s_js_i
         if terms[i+1] ≠ terms[i]-1 && terms[i+1] ≠ terms[i]+1 && terms[i] > terms[i+1]
             terms[i], terms[i+1] = terms[i+1], terms[i]
-            return _coxeter_reduce!(terms)
+            @goto start
         end
     end
     # (s_is_{i+1})^3 = I
     for i = 1:length(terms)-5
         if terms[i]+1 == terms[i+1] == terms[i+2]+1 == terms[i+3] == terms[i+4]+1 == terms[i+5]
-            return _coxeter_reduce!(deleteat!(terms, i:i+5))
+            deleteat!(terms, i:i+5)
+            @goto start
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,4 +87,5 @@ end
     @test Permutation(CoxeterDecomposition(5, Int[])).data ≈ 1:5
     @test Permutation(CoxeterDecomposition(5, [1])).data == [2; 1; 3:5]
     @test inv(CoxeterDecomposition(6, [1,3,5])) == CoxeterDecomposition(6, [1,3,5])
+    @test CoxeterDecomposition(RandomPermutation(100)) isa CoxeterDecomposition # check for stack overflow
 end


### PR DESCRIPTION
I ran into this problem:
```julia
julia> π = RandomPermutation(100)
(1,99,3,80,33,97,41,63,83,57,70,6,75,56,44,66,25,20,100,35,74,73,59,91,28,19,31,84,43,67,98,94,86,26,27,78,69,17,93,96,64,48,38,36,55,60,71,89,72,88,76,51,14,42,82)(2,90,62,53,21,46,12,58,30,50,39,34,4,40,47,13,8,65,68,5,92,18,87,49,9,95,79,61,52,16,77,7,85)(10,54)(11,29)(15)(22,24,32,45,23,37)(81)

julia> CoxeterDecomposition(π)
ERROR: StackOverflowError:
Stacktrace:
 [1] _coxeter_reduce!(terms::Vector{Int64}) (repeats 79984 times)
   @ Permutations ~/.julia/packages/Permutations/LXStU/src/Permutations.jl:374
```

The problem is that `_coxeter_reduce!` is recursive, and the recursion can be very deep for longer permutations. The algorithm mutates the `terms` vector in-place, so there's really no need for recursion here. To change this without needing to restructure too much, I used a `@label` and `@goto`. This can be changed into something more elegant, but I'd think addressing the stack overflow problem should be a high priority.