### PR TITLE
Allow a user to skip permutation validation

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -49,9 +49,9 @@ abstract type AbstractPermutation end
 """
 struct Permutation <: AbstractPermutation
     data::Vector{Int}
-    function Permutation(dat::Vector{Int})
+    function Permutation(dat::Vector{Int}; validate=true)
         n = length(dat)
-        if sort(dat) != collect(1:n)
+        if validate && sort(dat) != collect(1:n)
             error("Improper array: must be a permutation of 1:n")
         end
         new(dat)


### PR DESCRIPTION
Useful when we know that a permutation is valid and performance is critical. This should not reduce safety unless a user explicitly passes `verify=false`.

For example, if DataFrames uses this to permute more efficiently, when there is only one column, calling `cycles(Permutation(vector))` takes 64% of runtime, and 44% of that time is spent validating the input permutation, even though DataFrames's `permute!` advertises that "No checking is done to verify that `p` is a permutation."