### PR TITLE
add invpermute

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -27,7 +27,7 @@ import Random: randperm
 
 export Permutation, RandomPermutation
 export length, getindex, array, two_row
-export inv, cycles, cycle_string
+export invpermute, cycles, cycle_string
 export order, matrix, fixed_points
 export longest_increasing, longest_decreasing, reverse, sign
 export hash, dict, Transposition
@@ -157,6 +157,25 @@ function invperm(p::Permutation)
     end
     return Permutation(data)
 end
+
+"""
+    invpermute(v, p::AbstractVector)
+    invpermute(v, p::AbstractPermutation)
+
+Equivalent to `v[invperm(p)]` but often more efficient and does not check if `p` is a 
+permutation.
+"""
+Base.@propagate_inbounds function invpermute(v, p::AbstractVector)
+    out = similar(v)
+    out[p] = v
+    out
+end
+function invpermute(v, p::Permutation)
+    axes(v) == axes(p.data) || throw(DimensionMismatch("Data and permutation must have the same axes."))
+    @inbounds invpermute(v, p.data)
+end
+invpermute(v, p::AbstractPermutation) = invpermute(v, Permutation(p))
+
 
 # Find the cycles in a permutation
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,6 +178,14 @@ end
     end
 end
 
+@testset "inv" begin
+    p = RandomPermutation(12)
+    @test inv(inv(p)) == p
+    v = rand(12)
+    @test p * inv(p) == Permutation(12)
+    @test inv(p) == p' == invperm(p)
+end
+
 @testset "invpermute" begin
     v = rand(17)
     p = shuffle(1:17)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,4 +178,14 @@ end
     end
 end
 
+@testset "invpermute" begin
+    v = rand(17)
+    p = shuffle(1:17)
+    P = Permutation(p)
+    cp = CompiledPermutation(p)
+    @test v[invperm(p)] == invpermute(v, p) == invpermute(v, P) == invpermute(v, cp) == v[invperm(p)]
+    @test_throws DimensionMismatch invpermute(v, Permutation(shuffle(1:18)))
+    @test_throws DimensionMismatch invpermute(v, Permutation(shuffle(1:16)))
+end
+
 end


### PR DESCRIPTION
An optimized version of `v[invperm(p)]`.

(also stop exporting inv because it is already exported by Base)

```
julia> @benchmark invpermute(v, p) setup=(v=rand(3000); p=shuffle(1:3000))
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):   3.923 μs … 937.430 μs  ┊ GC (min … max):  0.00% … 98.58%
 Time  (median):      5.611 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   10.569 μs ±  50.582 μs  ┊ GC (mean ± σ):  31.72% ±  6.60%

        █▂                                                      
  ▂▆▃▁▂███▃▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  3.92 μs         Histogram: frequency by time         18.1 μs <

 Memory estimate: 23.48 KiB, allocs estimate: 2.

julia> @benchmark v[invperm(p)] setup=(v=rand(3000); p=shuffle(1:3000))
BenchmarkTools.Trial: 10000 samples with 3 evaluations.
 Range (min … max):   7.271 μs …   2.739 ms  ┊ GC (min … max):  0.00% … 98.90%
 Time  (median):     10.706 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   20.674 μs ± 104.696 μs  ┊ GC (mean ± σ):  27.27% ±  5.41%
```

From https://github.com/JuliaLang/julia/pull/44941#discussion_r847620024