### PR TITLE
minor refactoring in _coxeter_reduce!

### DIFF
--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -478,7 +478,7 @@ function _coxeter_reduce!(terms::Vector{Int})
             @goto start
         end
         # sort using sᵢsⱼ = sⱼsᵢ
-        if terms[i+1] ≠ terms[i] - 1 && terms[i+1] ≠ terms[i] + 1 && terms[i] > terms[i+1]
+        if terms[i+1] + 1 ≠ terms[i] && terms[i+1] ≠ terms[i] + 1 && terms[i] > terms[i+1]
             terms[i], terms[i+1] = terms[i+1], terms[i]
             @goto start
         end


### PR DESCRIPTION
While the two are equivalent, I find that using `+1` in all comparisons as opposed to having that singular `-1` makes things somewhat nicer as it makes the symmetry between the comparison obvious.